### PR TITLE
GG - Added a vertical-align bottom to #ng-text-roll

### DIFF
--- a/dev-app/src/app/components/ngTextRoll/ngtextroll.css
+++ b/dev-app/src/app/components/ngTextRoll/ngtextroll.css
@@ -1,5 +1,6 @@
 #ng-text-roll {
   display: inline-block;
+  vertical-align: bottom;
 }
 #ng-text-roll .outer {
   display: -webkit-box;


### PR DESCRIPTION
I believe this will fix your Firefox misalignment issue.  I tested in Chrome, Safari 8 and Firefox. Did not test in IE (so you might wanna do that).  I debugged this against your demo page. I think a better solution might be to take a different approach with some of the HTML surrounding your usage of the directive.  For example, I see a paragraph tag that wraps a lot of content.  I think you can get rid of that.  Might be able to chip away at some stuff like to hopefully avoid strangeness like this Firefox bug.  I also do not see a space in the rendered markup after the text that butts up against the directive in the demo.  If I add a space in dev tools, it works like you'd think...